### PR TITLE
Fix interference between extension and Pyroscope SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,9 @@ jar {
 
 shadowJar {
     archiveFileName = "pyroscope-otel.jar"
-    relocate 'io.pyroscope', 'io.otel.pyroscope.shadow'
+    relocate("io.pyroscope", "io.otel.pyroscope.shadow") {
+        exclude 'io.pyroscope.javaagent.ProfilerSdk'
+    }
     archiveClassifier.set('')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,6 @@ plugins {
 ext {
     versions = [
             opentelemetry              : "1.17.0",
-
-
             opentelemetryJavaagentAlpha: "1.17.0-alpha",
     ]
 
@@ -48,10 +46,6 @@ dependencies {
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure-spi:${versions.opentelemetry}")
     compileOnly("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:${versions.opentelemetryJavaagentAlpha}")
     compileOnly("io.opentelemetry.javaagent:opentelemetry-javaagent-extension-api:${versions.opentelemetryJavaagentAlpha}")
-
-
-
-
 }
 
 java {
@@ -60,7 +54,7 @@ java {
 }
 
 jar {
-    
+
 }
 
 shadowJar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pyroscope_version=0.15.2
+pyroscope_version=0.16.0
 otel_profiling_version=0.10.3

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-pyroscope_version=0.13.0
+pyroscope_version=0.15.2
 otel_profiling_version=0.10.3

--- a/src/main/java/io/otel/pyroscope/OtelProfilerSdkBridge.java
+++ b/src/main/java/io/otel/pyroscope/OtelProfilerSdkBridge.java
@@ -1,0 +1,71 @@
+package io.otel.pyroscope;
+
+import io.pyroscope.javaagent.api.ProfilerApi;
+import io.pyroscope.javaagent.api.ProfilerScopedContext;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class OtelProfilerSdkBridge implements ProfilerApi {
+
+    private final Object sdkInstance;
+
+    public OtelProfilerSdkBridge(Object sdkInstance) {
+        this.sdkInstance = sdkInstance;
+    }
+
+    @Override
+    public void startProfiling() {
+        try {
+            Method method = sdkInstance.getClass().getDeclaredMethod("startProfiling");
+            method.invoke(sdkInstance);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean isProfilingStarted() {
+        try {
+            Method method = sdkInstance.getClass().getDeclaredMethod("isProfilingStarted");
+            return (boolean) method.invoke(sdkInstance);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public ProfilerScopedContext createScopedContext(Map<String, String> labels) {
+        try {
+            Method method = sdkInstance.getClass().getDeclaredMethod("createScopedContext", Map.class);
+            Object ctx = method.invoke(sdkInstance, labels);
+
+            return new ProfilerScopedContext() {
+
+                @Override
+                public void forEachLabel(BiConsumer<String, String> biConsumer) {
+                    try {
+                        Method forEachLabelMethod = ctx.getClass().getDeclaredMethod("forEachLabel", BiConsumer.class);
+                        forEachLabelMethod.invoke(ctx, biConsumer);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                @Override
+                public void close() {
+                    try {
+                        Method closeMethod = ctx.getClass().getDeclaredMethod("close");
+                        closeMethod.invoke(ctx);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            };
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Provides a solution for #1, #10 and #12. This is just a proposal, there are perhaps other alternatives that could work as well.

### Background

When building the extension jar, we bundle a relocated Pyroscope SDK and async profiler binaries. We do this so that profiling itself and the tracing-profiling correlation can be achieved with no user-level code modifications. A user simply adds the open telemetry java agent and registers the pyroscope-otel jar as an extension:

```
OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar java -javaagent:opentelemetry-javaagent.jar ...
```

### Limitations

If an application already depends on the Pyroscope SDK (e.g., to add custom labels), and we want to correlate traces and profiles, we are faced with a problem. We effectively have 2 self-contained Pyroscope jars in the system, one from the SDK itself and one for the otel extension. Furthermore, the otel extension is loaded via an isolated class loader, which means we can't easily detect whether the Pyroscope SDK is present or not.

In some cases this will result in an exception like in #1 and #10. in other cases (#12, depending on used versions) we will end up with 2 profilers running and an undefined profiler output.

### Proposed solution

We introduce a `ProfilerApi` in the Pyroscope SDK, exposing basic profiling functionalities needed by this otel extension. When the extension runs, it will try to load an implementation of this API using the system class loader. If it succeeds, we use it for all future profiler interactions. If it fails for any reason, we do everything as we do today.

Depends on https://github.com/grafana/pyroscope-java/pull/176.

### Caveats

The extension runs early in the boot process. For it to be able to "see" the `ProfilerApi` implementation, we need to run Pyroscope in agent mode and the agent needs to be loaded before the open telemetry one:

```
OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar java -javaagent:pyroscope.jar -javaagent:opentelemetry-javaagent.jar ...
```

Users that don't explicitly need the Pyroscope SDK in their applications can omit this and run the extension like they do today:

```
OTEL_JAVAAGENT_EXTENSIONS=./pyroscope-otel.jar java -javaagent:opentelemetry-javaagent.jar 
```
