### PR TITLE
Fix GitHub Release creation by wiring shadowJar into assemble

### DIFF
--- a/otel-extension/build.gradle
+++ b/otel-extension/build.gradle
@@ -41,6 +41,8 @@ java {
     withSourcesJar()
 }
 
+assemble.dependsOn shadowJar
+
 shadowJar {
     archiveFileName = "pyroscope-otel-javaagent-extension.jar"
     relocate("io.pyroscope", "io.otel.pyroscope.shadow") {


### PR DESCRIPTION
## Summary
- The Shadow Gradle plugin with `java-library` does not automatically add `shadowJar` to the `assemble` lifecycle
- The publish workflow runs `assemble`, but the GitHub Release step expects `otel-extension/build/libs/pyroscope-otel-javaagent-extension.jar` which was never produced
- This caused the v2.0.1 GitHub Release creation to fail (Maven Central publish was unaffected)
- Fix: add `assemble.dependsOn shadowJar` in `otel-extension/build.gradle`

## Test plan
- [x] Verified locally that `./gradlew clean assemble` now produces both `otel-extension/build/libs/pyroscope-otel-javaagent-extension.jar` and `lib/build/libs/pyroscope-otel.jar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)