### PR TITLE
feat: add trace_id pprof label

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ link traces with the profiling data, and find specific lines of code related to 
 * Because of how sampling profilers work, spans shorter than the sample interval may not be captured. By default pyroscope CPU profiler probes stack traces 100 times per second, meaning that spans shorter than 10ms may not be captured.
 
 
-Java code can be easily instrumented with otel-profiling-java package -
-a `OpenTelemetry` implementation, that annotates profiling data with span IDs which makes it possible to filter
-out profile of a particular trace span in Pyroscope.
+Java code can be easily instrumented with the otel-profiling-java package, an `OpenTelemetry` implementation that annotates profiling data with `trace_id` and `span_id` labels, which makes it possible to filter the profile of a particular trace (or trace span) in Pyroscope.
 
 Visit [docs](https://grafana.com/docs/pyroscope/latest/configure-client/trace-span-profiles/java-span-profiles/) page for usage and configuration documentation.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-pyroscope_version=2.5.1
+pyroscope_version=2.6.0
 # x-release-please-start-version
 otel_profiling_version=2.0.6
 # x-release-please-end

--- a/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
+++ b/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
@@ -63,6 +63,9 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
 
         span.setAttribute(ATTRIBUTE_KEY_PROFILE_ID, strProfileId);
         asprof.setTracingContext(spanId, spanName);
+        String traceId = span.getSpanContext().getTraceId();
+        asprof.setTraceId(Long.parseUnsignedLong(traceId.substring(0, 16), 16),
+                          Long.parseUnsignedLong(traceId.substring(16, 32), 16));
     }
 
     @Override
@@ -71,6 +74,7 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
             return;
         }
         asprof.setTracingContext(0, 0);
+        asprof.setTraceId(0L, 0L);
     }
 
     public static long parseSpanId(String strProfileId) {

--- a/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
+++ b/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
@@ -63,9 +63,10 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
 
         span.setAttribute(ATTRIBUTE_KEY_PROFILE_ID, strProfileId);
         asprof.setTracingContext(spanId, spanName);
+        // W3C trace ID is 32 hex chars (128 bits). Parse directly into two longs
+        // to avoid the String#substring allocations on this hot path.
         String traceId = span.getSpanContext().getTraceId();
-        asprof.setTraceId(Long.parseUnsignedLong(traceId.substring(0, 16), 16),
-                          Long.parseUnsignedLong(traceId.substring(16, 32), 16));
+        asprof.setTraceId(parseHex64(traceId, 0), parseHex64(traceId, 16));
     }
 
     @Override
@@ -86,6 +87,25 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
         } catch (NumberFormatException e) {
             return 0;
         }
+    }
+
+    static long parseHex64(String s, int offset) {
+        long result = 0L;
+        for (int i = 0; i < 16; i++) {
+            int c = s.charAt(offset + i);
+            int nibble;
+            if (c >= '0' && c <= '9') {
+                nibble = c - '0';
+            } else if (c >= 'a' && c <= 'f') {
+                nibble = c - 'a' + 10;
+            } else if (c >= 'A' && c <= 'F') {
+                nibble = c - 'A' + 10;
+            } else {
+                throw new NumberFormatException("invalid hex char in trace_id at index " + (offset + i));
+            }
+            result = (result << 4) | nibble;
+        }
+        return result;
     }
 
     public static boolean isRootSpan(ReadableSpan span) {

--- a/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
+++ b/lib/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
@@ -66,7 +66,11 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
         // W3C trace ID is 32 hex chars (128 bits). Parse directly into two longs
         // to avoid the String#substring allocations on this hot path.
         String traceId = span.getSpanContext().getTraceId();
-        asprof.setTraceId(parseHex64(traceId, 0), parseHex64(traceId, 16));
+        try {
+            asprof.setTraceId(parseHex64(traceId, 0), parseHex64(traceId, 16));
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            asprof.setTraceId(0, 0);
+        }
     }
 
     @Override

--- a/otel-extension/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
+++ b/otel-extension/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
@@ -52,6 +52,7 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
 
         span.setAttribute(ATTRIBUTE_KEY_PROFILE_ID, strProfileId);
         api.setTracingContext(spanId, spanName);
+        api.setTraceId(span.getSpanContext().getTraceId());
     }
 
     @Override
@@ -59,7 +60,9 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
         if (configuration.rootSpanOnly && !isRootSpan(span)) {
             return;
         }
-        getProfiler().setTracingContext(0, 0);
+        ProfilerApi api = getProfiler();
+        api.setTracingContext(0, 0);
+        api.clearTraceId();
     }
 
     public static long parseSpanId(String strProfileId) {

--- a/otel-extension/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
+++ b/otel-extension/src/main/java/io/otel/pyroscope/PyroscopeOtelSpanProcessor.java
@@ -52,7 +52,11 @@ public final class PyroscopeOtelSpanProcessor implements SpanProcessor {
 
         span.setAttribute(ATTRIBUTE_KEY_PROFILE_ID, strProfileId);
         api.setTracingContext(spanId, spanName);
-        api.setTraceId(span.getSpanContext().getTraceId());
+        try {
+            api.setTraceId(span.getSpanContext().getTraceId());
+        } catch (NumberFormatException | IndexOutOfBoundsException e) {
+            api.clearTraceId();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Summary

Attaches a `trace_id` pprof label (32-char W3C hex) to profile samples, enabling traces↔profiles correlation by trace ID server-side. Emitted unconditionally, matching the Go/Python SDKs; `span_id` and `pyroscope.profile.id` behavior is unchanged.

Uses the `ProfilerApi.setTraceId(String)` / `clearTraceId()` methods added in grafana/pyroscope-java#313 (the otel-extension path). The library processor calls the native `AsyncProfiler.setTraceId(hi, lo)` directly, with an allocation-free hex parser.

Requires pyroscope-java >= 2.6.0 (now on Maven Central).
