### PR TITLE
chore: bump itest go toolchain to 1.26.3

### DIFF
--- a/itest/go.mod
+++ b/itest/go.mod
@@ -2,6 +2,8 @@ module otel-profiling-java-itest
 
 go 1.25.0
 
+toolchain go1.26.3
+
 require (
 	connectrpc.com/connect v1.19.1
 	github.com/dennwc/varint v1.0.0


### PR DESCRIPTION
Add a `toolchain go1.26.3` directive to `itest/go.mod` to pin the build toolchain to the latest Go 1.26 release. The `go` language version directive stays at `1.25.0`.

`go mod verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)