### PR TITLE
fix(create-github-app-token): bump version to 0.3.1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,7 +21,7 @@ jobs:
       version: ${{ steps.rp.outputs.version }}
     steps:
       - id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@580590a644e82e79bb2598bdaba0be245a14dda0 # create-github-app-token/v0.2.2
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
         with:
           github_app: pyroscope-development-app
 


### PR DESCRIPTION
Bumping version as part of https://github.com/grafana/otel-profiling-java/compare/phlope/bump-create-github-token-to-0.3.1?expand=1

See
https://docs.google.com/spreadsheets/d/1tP9zZv1bfaD7bgnF-BSlqXdlcoz2KT360a9csxw7eZ4/edit?gid=0#gid=0
